### PR TITLE
Compute initial navigation route

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -111,6 +111,7 @@ export default function App() {
   const requests = new Requests();
   const householdManager = new HouseholdManager(requests);
   const sessionData = new SessionData();
+  const initialRoute = sessionData.idToken ? 'Main' : 'Login';
   const navigationRef = useRef<any>(null);
 
   const toggleAddProductModal = () => {
@@ -182,10 +183,10 @@ export default function App() {
   useEffect(() => {
     const checkAuthStatus = async () => {
       const idToken = sessionData.idToken;
-      setIsLoading(false);
       if (idToken) {
         handleLoginSuccess();
       }
+      setIsLoading(false);
     };
 
     checkAuthStatus();
@@ -320,7 +321,7 @@ export default function App() {
             translucent={true}
           />
           <NavigationContainer ref={navigationRef}>
-            <Stack.Navigator initialRouteName="Login">
+            <Stack.Navigator initialRouteName={initialRoute}>
               <Stack.Screen name="Login" options={{ headerShown: false }}>
                 {(props) => <Login {...props} onLoginSuccess={handleLoginSuccess} />}
               </Stack.Screen>


### PR DESCRIPTION
## Summary
- calculate initial route based on saved SessionData
- use the calculated route for Stack.Navigator
- avoid early `isLoading` updates when checking auth

## Testing
- `./run_tests.sh --basic-flake8`
- `./run_tests.sh --complex-flake8`
- `./run_tests.sh --mypy`


------
https://chatgpt.com/codex/tasks/task_e_68608a0b34dc8331bc547567d55a1bb2